### PR TITLE
Fix bidi behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ npm-debug.log
 # project specific
 lib/mappingTable.json
 lib/regexes.js
-test/unicode/
+test/fixtures/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "mocha",
     "lint": "eslint .",
-    "pretest": "node scripts/getLatestUnicodeTests.js",
+    "pretest": "node scripts/getLatestTests.js",
     "prepublish": "node scripts/generateMappingTable.js && node scripts/generateRegexes.js"
   },
   "repository": "Sebmaster/tr46.js",

--- a/scripts/getLatestTests.js
+++ b/scripts/getLatestTests.js
@@ -10,6 +10,10 @@ const path = require("path");
 const request = require("request");
 const { unicodeVersion } = require("../package.json");
 
-const target = fs.createWriteStream(path.resolve(__dirname, "../test/unicode/IdnaTest.txt"));
+const target = fs.createWriteStream(path.resolve(__dirname, "../test/fixtures/IdnaTest.txt"));
 request.get(`http://www.unicode.org/Public/idna/${unicodeVersion}/IdnaTest.txt`)
   .pipe(target);
+
+const asciiTarget = fs.createWriteStream(path.resolve(__dirname, "../test/fixtures/toascii.json"));
+request.get("https://rawgit.com/w3c/web-platform-tests/785ec55ddc2dc2e5dfecac65832d68c82f72e50b/url/toascii.json")
+  .pipe(asciiTarget);

--- a/test/toascii.js
+++ b/test/toascii.js
@@ -1,0 +1,37 @@
+/* eslint-env node, mocha */
+"use strict";
+
+const assert = require("assert");
+const tr46 = require("../index.js");
+
+const toASCIITestCases = require("./fixtures/toascii.json");
+
+function testToASCII(testCase) {
+  return () => {
+    const result = tr46.toASCII(testCase.input, {
+      checkBidi: true,
+      checkHyphens: false,
+      checkJoiners: true,
+      useSTD3ASCIIRules: false,
+      verifyDNSLength: false
+    });
+
+    assert.strictEqual(result, testCase.output);
+  };
+}
+
+describe("ToASCII", () => {
+  for (const testCase of toASCIITestCases) {
+    if (typeof testCase === "string") {
+      // It's a "comment"; skip it.
+      continue;
+    }
+
+    let description = testCase.input;
+    if (testCase.comment) {
+      description = ` (${testCase.comment})`;
+    }
+
+    specify(description, testToASCII(testCase));
+  }
+});

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -45,13 +45,23 @@ function testConversionOption(test, option) {
 }
 
 function testConversion(test) {
-  return () => {
+  return function () {
     if (test[0] === "B" || test[0] === "N") {
       testConversionOption(test, "nontransitional");
     }
 
     if (test[0] === "B" || test[0] === "T") {
       testConversionOption(test, "transitional");
+    }
+
+    // If the ToUnicode error code is [A4_2], it means that the test is buggy. See
+    // https://github.com/Sebmaster/tr46.js/pull/13#issuecomment-318874337.
+
+    // The `this.skip()` line below will show the entire test is skipped in Mocha's output, but in fact toASCII is still
+    // tested above (and an error will be thrown if toASCII breaks).
+    if (test[2].trim() === "[A4_2]") {
+      this.skip(); // eslint-disable-line no-invalid-this
+      return;
     }
 
     // ToUnicode is always non-transitional.

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -69,7 +69,7 @@ function testConversion(test) {
   };
 }
 
-const lines = fs.readFileSync(path.resolve(__dirname, "unicode", "IdnaTest.txt"), { encoding: "utf8" })
+const lines = fs.readFileSync(path.resolve(__dirname, "fixtures", "IdnaTest.txt"), { encoding: "utf8" })
   .split("\n")
   .map(l => l.split("#")[0]);
 


### PR DESCRIPTION
Bidi rules are hard. 

There's a definition of a "bidi domain" in the UTS46 spec, however adding a check for that, breaks some IdnaTest.txt tests. @TimothyGu Any idea what this could be?